### PR TITLE
Improve validation of phone numbers

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,6 +9,9 @@ twilio
 django_otp
 qrcode
 
+# Optional - improves phone number validation.
+phonenumbers
+
 # Example app
 
 django-debug-toolbar

--- a/two_factor/models.py
+++ b/two_factor/models.py
@@ -2,6 +2,7 @@ from binascii import unhexlify
 import logging
 
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
@@ -25,7 +26,10 @@ logger = logging.getLogger(__name__)
 if phonenumbers:
     def phone_number_validator(phone_number):
         try:
-            phonenumbers.parse(phone_number, None)
+            num = phonenumbers.parse(phone_number, None)
+            if not phonenumbers.is_valid_number(num):
+                raise ValidationError(_('Please enter a valid phone number, including your country code '
+                                        'starting with + or 00.'))
         except phonenumbers.phonenumberutil.NumberParseException:
             raise ValidationError(_('Please enter a valid phone number, including your country code '
                                     'starting with + or 00.'))


### PR DESCRIPTION
Use `phonenumbers` to validate phone numbers so that things like '+10' and '003' as well as things like '+123456789100' (too many digits) are not allowed. This used to cause a twilio error, now it returns a nice message. When `phonenumbers` is not installed, revert to the old method of validation.
